### PR TITLE
small text improvement

### DIFF
--- a/PythonNNExampleFromSirajology.ipynb
+++ b/PythonNNExampleFromSirajology.ipynb
@@ -93,7 +93,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The seed for the random generator is set so that it will return the same random numbers each time, which is sometimes useful for debugging."
+    "The seed for the random generator is set so that it will return the same random numbers each time re-running the script, which is sometimes useful for debugging."
    ]
   },
   {


### PR DESCRIPTION
Re-running a cell generating random numbers in jupyter doesn't give the same result when seed is set. But it helps when saying "Kernel Restart & Run All" then the random numbers stay the same